### PR TITLE
Change Set internals and make (extreme) performance improvements

### DIFF
--- a/helper/schema/field_reader_config_test.go
+++ b/helper/schema/field_reader_config_test.go
@@ -228,8 +228,8 @@ func TestConfigFieldReader_ComputedSet(t *testing.T) {
 		"set, normal": {
 			[]string{"strSet"},
 			FieldReadResult{
-				Value: map[int]interface{}{
-					2356372769: "foo",
+				Value: map[string]interface{}{
+					"2356372769": "foo",
 				},
 				Exists:   true,
 				Computed: false,

--- a/helper/schema/field_writer_map.go
+++ b/helper/schema/field_writer_map.go
@@ -298,8 +298,7 @@ func (w *MapFieldWriter) setSet(
 	}
 
 	for code, elem := range value.(*Set).m {
-		codeStr := strconv.FormatInt(int64(code), 10)
-		if err := w.set(append(addrCopy, codeStr), elem); err != nil {
+		if err := w.set(append(addrCopy, code), elem); err != nil {
 			return err
 		}
 	}

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -228,7 +228,7 @@ func (d *ResourceData) State() *terraform.InstanceState {
 	// attribute set as a map[string]interface{}, write it to a MapFieldWriter,
 	// and then use that map.
 	rawMap := make(map[string]interface{})
-	for k, _ := range d.schema {
+	for k := range d.schema {
 		source := getSourceSet
 		if d.partial {
 			source = getSourceState
@@ -343,13 +343,13 @@ func (d *ResourceData) diffChange(
 }
 
 func (d *ResourceData) getChange(
-	key string,
+	k string,
 	oldLevel getSource,
 	newLevel getSource) (getResult, getResult) {
 	var parts, parts2 []string
-	if key != "" {
-		parts = strings.Split(key, ".")
-		parts2 = strings.Split(key, ".")
+	if k != "" {
+		parts = strings.Split(k, ".")
+		parts2 = strings.Split(k, ".")
 	}
 
 	o := d.get(parts, oldLevel)
@@ -372,13 +372,6 @@ func (d *ResourceData) get(addr []string, source getSource) getResult {
 		level = "config"
 	} else {
 		level = "state"
-	}
-
-	// Build the address of the key we're looking for and ask the FieldReader
-	for i, v := range addr {
-		if v[0] == '~' {
-			addr[i] = v[1:]
-		}
 	}
 
 	var result FieldReadResult

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1509,9 +1509,9 @@ func TestResourceDataSet(t *testing.T) {
 
 			Key: "ports",
 			Value: &Set{
-				m: map[int]interface{}{
-					1: 1,
-					2: 2,
+				m: map[string]interface{}{
+					"1": 1,
+					"2": 2,
 				},
 			},
 
@@ -1546,7 +1546,7 @@ func TestResourceDataSet(t *testing.T) {
 			Err:   true,
 
 			GetKey:   "ports",
-			GetValue: []interface{}{80, 100},
+			GetValue: []interface{}{100, 80},
 		},
 
 		// #11: Set with nested set

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -866,23 +866,16 @@ func (m schemaMap) diffSet(
 
 	// Build the list of codes that will make up our set. This is the
 	// removed codes as well as all the codes in the new codes.
-	codes := make([][]int, 2)
+	codes := make([][]string, 2)
 	codes[0] = os.Difference(ns).listCode()
 	codes[1] = ns.listCode()
 	for _, list := range codes {
 		for _, code := range list {
-			// If the code is negative (first character is -) then
-			// replace it with "~" for our computed set stuff.
-			codeStr := strconv.Itoa(code)
-			if codeStr[0] == '-' {
-				codeStr = string('~') + codeStr[1:]
-			}
-
 			switch t := schema.Elem.(type) {
 			case *Resource:
 				// This is a complex resource
 				for k2, schema := range t.Schema {
-					subK := fmt.Sprintf("%s.%s.%s", k, codeStr, k2)
+					subK := fmt.Sprintf("%s.%s.%s", k, code, k2)
 					err := m.diff(subK, schema, diff, d, true)
 					if err != nil {
 						return err
@@ -896,7 +889,7 @@ func (m schemaMap) diffSet(
 
 				// This is just a primitive element, so go through each and
 				// just diff each.
-				subK := fmt.Sprintf("%s.%s", k, codeStr)
+				subK := fmt.Sprintf("%s.%s", k, code)
 				err := m.diff(subK, &t2, diff, d, true)
 				if err != nil {
 					return err

--- a/helper/schema/set_test.go
+++ b/helper/schema/set_test.go
@@ -11,7 +11,7 @@ func TestSetAdd(t *testing.T) {
 	s.Add(5)
 	s.Add(25)
 
-	expected := []interface{}{1, 5, 25}
+	expected := []interface{}{1, 25, 5}
 	actual := s.List()
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
@@ -101,7 +101,7 @@ func TestSetUnion(t *testing.T) {
 	union := s1.Union(s2)
 	union.Add(2)
 
-	expected := []interface{}{1, 2, 5, 25}
+	expected := []interface{}{1, 2, 25, 5}
 	actual := union.List()
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)


### PR DESCRIPTION
Changing the Set internals makes a lot of sense as it saves doing conversions in multiple places and gives a central place to alter the key when a item is computed.

This will have no side effects other then that the ordering is now based on strings instead on integers, so the order will be different. This will however have no effect on existing configs as these will use the individual codes/keys and not the ordering to determine if there is a diff or not.

Lastly (but I think also most importantly) there is a fix in this PR that makes diffing sets extremely more performand. Before a full diff required reading the complete Set for every single parameter/attribute you wanted to diff, while now it only gets that specific parameter.

We have a use case where we have a Set that has 18 parameters and the set consist of about 600 items (don't ask :wink:). So when doing a diff it would take 100% CPU of all cores and stay that way for almost an hour before being able to complete the diff.

Debugging this we learned that for retrieving every single parameter it made over 52.000 calls to `func (c *ResourceConfig) get(..)`. In this function a slice is created and used only for the duration of the
call, so the time needed to create all needed slices and on the other hand the time the garbage collector needed to clean them up again caused the system to cripple itself. Next to that there are also some expensive reflect calls in this function which also claimed a fair amount of CPU time.

After this fix the number of calls needed to get a single parameter dropped from 52.000+ to only 2! :smiley: